### PR TITLE
DOM Selector changes, delete duplicate function

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,7 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    console.log(changeInfo)
-    setTimeout(function () {
-        console.log("loaded")
-        chrome.tabs.sendMessage(tabId, "discord")
-    }, 4000);
-
+  console.log(changeInfo);
+  setTimeout(function () {
+    console.log('loaded');
+    chrome.tabs.sendMessage(tabId, 'discord');
+  }, 2000);
 });

--- a/content.js
+++ b/content.js
@@ -1,13 +1,14 @@
 chrome.runtime.onMessage.addListener(function (res) {
 
     //Beta for the share button inside the page
-    if(res == "discord"){
-        function artShare(webhook,type){
-            let button;
-            if(type == "sfw")
-            button = document.getElementById("PixcordSFW");
-            else if (type == "nsfw")
-            button = document.getElementById("PixcordNSFW")
+    let button;
+    if (type) {
+      button =
+        type === 'sfw'
+          ? document.getElementById('PixcordSFW')
+          : document.getElementById('PixcordNSFW');
+      button.innerHTML = '<img src="https://i.imgur.com/4LBBzRr.gif">';
+    }
 
     var request = new XMLHttpRequest();
     request.open('POST', webhook);

--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 chrome.runtime.onMessage.addListener(function (res) {
-
-    //Beta for the share button inside the page
+  //Beta for the share button inside the page
+  function artShare(webhook, type) {
     let button;
     if (type) {
       button =
@@ -116,130 +116,49 @@ chrome.runtime.onMessage.addListener(function (res) {
     };
   }
 
-        if(!document.getElementById("PixcordSFW")){
-            //Creating the first div
-            let divSFW = document.createElement("div");
-            divSFW.className = "sc-181ts2x-3 iujCSd"
+  if (res.includes('webhooks')) {
+    artShare(res);
+  } else {
+    if (!document.getElementById('PixcordSFW')) {
+      //Creating the first div
+      let divSFW = document.createElement('div');
+      divSFW.className = 'sc-181ts2x-3 iujCSd';
 
+      //SFW Button
+      let sfw = document.createElement('BUTTON'); // Create a <button> node
+      sfw.setAttribute('id', 'PixcordSFW');
+      sfw.onclick = function () {
+        artShare(
+          'https://discordapp.com/api/webhooks/547508568849383426/3ceqXPSXNmnEHikyR65GL0UHTJoASHZWeu49Re5IhBYszSjMwDv8hfspWFso_SoQ4SBI',
+          'sfw'
+        );
+      };
+      let t = document.createTextNode('Share to #art'); // Create a text node
+      sfw.appendChild(t); // Append the text to <p>
+      divSFW.appendChild(sfw);
+      document
+        .getElementsByClassName('sc-181ts2x-0 jPZrYy')[0]
+        .appendChild(divSFW); // Append to <div>
 
-            //SFW Button
-            let sfw = document.createElement("BUTTON");  // Create a <button> node
-            sfw.setAttribute("id", "PixcordSFW")
-            sfw.onclick = function () {
-                artShare("https://discordapp.com/api/webhooks/547508568849383426/3ceqXPSXNmnEHikyR65GL0UHTJoASHZWeu49Re5IhBYszSjMwDv8hfspWFso_SoQ4SBI","sfw")
-            };
-            let t = document.createTextNode("Share to #art");      // Create a text node
-            sfw.appendChild(t);                                          // Append the text to <p>
-            divSFW.appendChild(sfw);
-            document.getElementsByClassName("sc-181ts2x-0 jPZrYy")[0].appendChild(divSFW);           // Append to <div>
+      //Second div
+      let divNSFW = document.createElement('div');
+      divNSFW.className = 'sc-181ts2x-3 iujCSd';
 
-            //Second div
-            let divNSFW = document.createElement("div");
-            divNSFW.className = "sc-181ts2x-3 iujCSd"
-
-            //NSFW Button
-            let nsfw = document.createElement("BUTTON");  // Create a <button> node
-            nsfw.setAttribute("id", "PixcordNSFW")
-            nsfw.onclick = function () {
-                artShare("https://discordapp.com/api/webhooks/738107690672324639/GQeX-g04uhrHrLbxM4qV2E1ePRbUeXZd9xwX7lJCVcJDtrY-Bs3pSA15mm2cjoewQjxb","nsfw")
-            };
-            let t2 = document.createTextNode("Share to #NSFW");      // Create a text node
-            nsfw.appendChild(t2);  // Append the text to <p>
-            divNSFW.appendChild(nsfw)
-            document.getElementsByClassName("sc-181ts2x-0 jPZrYy")[0].appendChild(divNSFW);           // Append to <div>
-        }
-    } else{ //Sharing through the popup
-        var request = new XMLHttpRequest();
-        request.open("POST", res);
-
-        var xhr = new XMLHttpRequest();
-        var xhr2 = new XMLHttpRequest();
-
-
-
-        //Art upload settings
-        xhr.open("POST", "https://api.imgur.com/3/image");
-        xhr.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
-
-        var dataFields = new FormData();
-        dataFields.append('image', document.getElementsByClassName('sc-1qpw8k9-1 fvHoJ')[0].src);
-        dataFields.append('type', 'URL');
-        xhr.send(dataFields)
-
-        //Profile picture upload settings
-        xhr2.open("POST", "https://api.imgur.com/3/image");
-        xhr2.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
-
-
-        let firstStep = document.getElementsByClassName('sc-1asno00-0 iyBsWP')[0].innerHTML.replace('<img src="', '');
-        console.log(firstStep)
-        let profileImg = firstStep.replace('" width="40" height="40" alt="' + document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].innerHTML + '" style="object-fit: cover; object-position: center top;">', '')
-        var dataFields2 = new FormData();
-        dataFields2.append('image', profileImg);
-        dataFields2.append('type', 'URL');
-
-
-
-        xhr.onloadend = function (evt) {
-            var responseJSON = JSON.parse(xhr.responseText);
-
-
-            xhr2.send(dataFields2)
-            xhr2.onloadend = function (evt) {
-                var profileJSON = JSON.parse(xhr2.responseText);
-
-                request.setRequestHeader('Content-type', 'application/json');
-                //get name and profile pic
-                chrome.storage.sync.get({
-                    name: 'Pixcord',
-                    discordImage: 'blue'
-                }, function (items) {
-                    //document.getElementById('discordName').value = items.name;
-                    //document.getElementById('discordIMG').value = items.discordImage;
-
-                    var params = {
-                        username: items.name,
-                        avatar_url: items.discordImage,
-                        content: "",
-                        embeds: [
-                            {
-                                "title": document.getElementsByClassName('sc-1u8nu73-3')[0].innerHTML,
-                                "url": location.href,
-                                "color": 7506394,
-                                "author": {
-                                    "name": document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].innerHTML,
-                                    "url": document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].href,
-                                    "icon_url": profileJSON.data.link
-                                },
-                                "footer": {
-                                    "text": "Pixcord developed by @DaikiPT"
-                                },
-                                "timestamp": new Date(),
-                                "image": {
-                                    "url": responseJSON.data.link
-                                }
-                            }
-                        ]
-                    }
-                    request.send(JSON.stringify(params));
-                    alert("Shared")
-
-
-                })
-
-
-            }
-
-
-        };
-
-        xhr.onerror = function (err) { // untested
-            //console.log('Failed uploading image from ' + fileName + ': ' + JSON.stringify(err));
-            //console.log('Output: ' + xhr.responseText);
-            alert("Pixcord Upload Error")
-        };
-
+      //NSFW Button
+      let nsfw = document.createElement('BUTTON'); // Create a <button> node
+      nsfw.setAttribute('id', 'PixcordNSFW');
+      nsfw.onclick = function () {
+        artShare(
+          'https://discordapp.com/api/webhooks/738107690672324639/GQeX-g04uhrHrLbxM4qV2E1ePRbUeXZd9xwX7lJCVcJDtrY-Bs3pSA15mm2cjoewQjxb',
+          'nsfw'
+        );
+      };
+      let t2 = document.createTextNode('Share to #NSFW'); // Create a text node
+      nsfw.appendChild(t2); // Append the text to <p>
+      divNSFW.appendChild(nsfw);
+      document
+        .getElementsByClassName('sc-181ts2x-0 jPZrYy')[0]
+        .appendChild(divNSFW); // Append to <div>
     }
-
-})
-
+  }
+});

--- a/content.js
+++ b/content.js
@@ -9,96 +9,111 @@ chrome.runtime.onMessage.addListener(function (res) {
             else if (type == "nsfw")
             button = document.getElementById("PixcordNSFW")
 
-            button.innerHTML = '<img src="https://i.imgur.com/4LBBzRr.gif">'
-            var request = new XMLHttpRequest();
-            request.open("POST", webhook);
+    var request = new XMLHttpRequest();
+    request.open('POST', webhook);
 
-            var xhr = new XMLHttpRequest();
-            var xhr2 = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest();
+    var xhr2 = new XMLHttpRequest();
 
+    //Art upload settings
+    xhr.open('POST', 'https://api.imgur.com/3/image');
+    xhr.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
 
+    var dataFields = new FormData();
 
-            //Art upload settings
-            xhr.open("POST", "https://api.imgur.com/3/image");
-            xhr.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
+    var imgSrc = document
+      .querySelector('.gtm-expand-full-size-illust')
+      .querySelector('img').src;
 
-            var dataFields = new FormData();
-            dataFields.append('image', document.getElementsByClassName('sc-1qpw8k9-1 fvHoJ')[0].src);
-            dataFields.append('type', 'URL');
-            xhr.send(dataFields)
+    // Other methods of getting image source in case something breaks
+    // document.querySelectorAll('[role="presentation"]')[2]?.querySelector('img').src
+    //document.getElementsByClassName('sc-1qpw8k9-1 fvHoJ')[0].src;
 
-            //Profile picture upload settings
-            xhr2.open("POST", "https://api.imgur.com/3/image");
-            xhr2.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
+    dataFields.append('image', imgSrc);
+    dataFields.append('type', 'URL');
+    xhr.send(dataFields);
 
+    //Profile picture upload settings
+    xhr2.open('POST', 'https://api.imgur.com/3/image');
+    xhr2.setRequestHeader('Authorization', 'Client-ID d2906dca59f16f0');
 
-            let firstStep = document.getElementsByClassName('sc-1asno00-0 iyBsWP')[0].innerHTML.replace('<img src="', '');
-            let profileImg = firstStep.replace('" width="40" height="40" alt="' + document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].innerHTML + '" style="object-fit: cover; object-position: center top;">', '')
-            var dataFields2 = new FormData();
-            dataFields2.append('image', profileImg);
-            dataFields2.append('type', 'URL');
-            let artTitle = "Untitled"
+    // let firstStep = document
+    //   .getElementsByClassName('sc-1asno00-0 iyBsWP')[0]
+    //   .innerHTML.replace('<img src="', '');
+    // let profileImg = firstStep.replace(
+    //   '" width="40" height="40" alt="' +
+    //     document.getElementsByClassName('sc-fzozJi daCWkW')[0].innerText +
+    //     '" style="object-fit: cover; object-position: center top;">',
+    //   ''
+    // );
 
-            if(document.getElementsByClassName('sc-1u8nu73-3')[0])
-                artTitle = document.getElementsByClassName('sc-1u8nu73-3')[0].innerHTML
+    const profileLinks = document
+      .querySelector('aside')
+      .querySelectorAll('a[href^="/en/users/"]');
+    const profileImg = profileLinks[0].querySelector('img').src;
+    const profileName = profileLinks[1].innerHTML;
 
-            xhr.onloadend = function (evt) {
-                var responseJSON = JSON.parse(xhr.responseText);
+    var dataFields2 = new FormData();
+    dataFields2.append('image', profileImg);
+    dataFields2.append('type', 'URL');
 
+    const artDescription = document.querySelector('figcaption');
+    const artTitle =
+      artDescription.querySelector('h1')?.innerHTML || 'Untitled';
 
-                xhr2.send(dataFields2)
-                xhr2.onloadend = function (evt) {
-                    var profileJSON = JSON.parse(xhr2.responseText);
+    xhr.onloadend = function (evt) {
+      var responseJSON = JSON.parse(xhr.responseText);
 
-                    request.setRequestHeader('Content-type', 'application/json');
-                    //get name and profile pic
-                    chrome.storage.sync.get({
-                        name: 'Pixcord',
-                        discordImage: 'https://i.imgur.com/VQFaBcn.png'
-                    }, function (items) {
+      xhr2.send(dataFields2);
+      xhr2.onloadend = function (evt) {
+        var profileJSON = JSON.parse(xhr2.responseText);
 
-                        var params = {
-                            username: items.name,
-                            avatar_url: items.discordImage,
-                            content: "",
-                            embeds: [
-                                {
-                                    "title": artTitle ,
-                                    "url": location.href,
-                                    "color": 7506394,
-                                    "author": {
-                                        "name": document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].innerHTML,
-                                        "url": document.getElementsByClassName('sc-fzozJi iFrcHJ')[0].href,
-                                        "icon_url": profileJSON.data.link
-                                    },
-                                    "footer": {
-                                        "text": "Pixcord developed by @DaikiPT"
-                                    },
-                                    "timestamp": new Date(),
-                                    "image": {
-                                        "url": responseJSON.data.link
-                                    }
-                                }
-                            ]
-                        }
-                        request.send(JSON.stringify(params));
-                        button.innerHTML = '✔️Shared'
-
-
-                    })
-
-
+        request.setRequestHeader('Content-type', 'application/json');
+        //get name and profile pic
+        chrome.storage.sync.get(
+          {
+            name: 'Pixcord',
+            discordImage: 'https://i.imgur.com/VQFaBcn.png'
+          },
+          function (items) {
+            var params = {
+              username: items.name,
+              avatar_url: items.discordImage,
+              content: '',
+              embeds: [
+                {
+                  title: artTitle,
+                  url: location.href,
+                  color: 7506394,
+                  author: {
+                    profileName,
+                    url: profileLinks[0].href,
+                    icon_url: profileJSON.data.link
+                  },
+                  footer: {
+                    text: 'Pixcord developed by @DaikiPT'
+                  },
+                  timestamp: new Date(),
+                  image: {
+                    url: responseJSON.data.link
+                  }
                 }
-
-
+              ]
             };
+            request.send(JSON.stringify(params));
+            button ? (button.innerHTML = '✔️Shared') : null;
+          }
+        );
+      };
+    };
 
-            xhr.onerror = function (err) { // untested
-                //console.log('Failed uploading image from ' + fileName + ': ' + JSON.stringify(err));
-                //console.log('Output: ' + xhr.responseText);
-                alert("Pixcord Upload Error")
-            };
-        }
+    xhr.onerror = function (err) {
+      // untested
+      //console.log('Failed uploading image from ' + fileName + ': ' + JSON.stringify(err));
+      //console.log('Output: ' + xhr.responseText);
+      alert('Pixcord Upload Error');
+    };
+  }
 
         if(!document.getElementById("PixcordSFW")){
             //Creating the first div

--- a/index.js
+++ b/index.js
@@ -1,19 +1,22 @@
-window.addEventListener('DOMContentLoaded', (event) => {
-    document.getElementById("sfwShare").addEventListener("click", onclick);
-    document.getElementById("nsfwShare").addEventListener("click", onclickNSFW);
-
+window.addEventListener('DOMContentLoaded', event => {
+  document.getElementById('sfwShare').addEventListener('click', onclick);
+  document.getElementById('nsfwShare').addEventListener('click', onclickNSFW);
 });
 
-function onclick(){
-    chrome.tabs.query({currentWindow: true, active: true},
-    function(tabs){
-        chrome.tabs.sendMessage(tabs[0].id, "https://discordapp.com/api/webhooks/547508568849383426/3ceqXPSXNmnEHikyR65GL0UHTJoASHZWeu49Re5IhBYszSjMwDv8hfspWFso_SoQ4SBI")
-    })
+function onclick() {
+  chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+    chrome.tabs.sendMessage(
+      tabs[0].id,
+      'https://discordapp.com/api/webhooks/547508568849383426/3ceqXPSXNmnEHikyR65GL0UHTJoASHZWeu49Re5IhBYszSjMwDv8hfspWFso_SoQ4SBI'
+    );
+  });
 }
 
-function onclickNSFW(){
-    chrome.tabs.query({currentWindow: true, active: true},
-    function(tabs){
-        chrome.tabs.sendMessage(tabs[0].id, "https://discordapp.com/api/webhooks/738107690672324639/GQeX-g04uhrHrLbxM4qV2E1ePRbUeXZd9xwX7lJCVcJDtrY-Bs3pSA15mm2cjoewQjxb")
-    })
+function onclickNSFW() {
+  chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+    chrome.tabs.sendMessage(
+      tabs[0].id,
+      'https://discordapp.com/api/webhooks/738107690672324639/GQeX-g04uhrHrLbxM4qV2E1ePRbUeXZd9xwX7lJCVcJDtrY-Bs3pSA15mm2cjoewQjxb'
+    );
+  });
 }

--- a/popup.html
+++ b/popup.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <script src="index.js" charset="utf-8"></script>
 </head>
-<body>
-    <button class="btn btn-primary" id="sfwShare">Share to #art</button>
-    <button class="btn btn-danger" id="nsfwShare">Share to #NSFW</button>
+
+<body style="width: 200px">
+    <div style="display: flex;">
+        <button class="btn btn-sm btn-primary" id="sfwShare">Share to #art</button>
+        <button class="btn btn-sm btn-danger" id="nsfwShare">Share to #NSFW</button>
+    </div>
 </body>
+
 </html>


### PR DESCRIPTION
Main changes:

- Selecting where the share buttons are inserted in the page is no longer done with specific classes in case pixiv changes them, but instead by selecting elements that are less likely to change, like `.gtm-expand-fullsize-illust`, and using `aside` to get the profile links and icon.
- Popup buttons remain but are now smaller and side by side, and now use the same artShare function.